### PR TITLE
Implement readable Card.__str__ output ("Rank of Suit") — fixes #1

### DIFF
--- a/backend/deck.py
+++ b/backend/deck.py
@@ -19,7 +19,7 @@ class Card:
       """
       Return a readable version of card for CLI printout
       """
-      return self.rank + self.suit
+      return f"{self.rank} of {self.suit}"
 
    def __repr__(self):
       """


### PR DESCRIPTION
### Summary
- Updated the `__str__` method in the `Card` class to return a readable string in the format "Rank of Suit".
- Example: "A of Spades" instead of "AS".
- Improves output readability when printing cards in the CLI.

### Related Issue
Fixes #1 (Card class implementation)

### Notes
This change only modifies the `Card` class string output and does not affect other logic.
